### PR TITLE
Fix overflowing integer, use BigNumber

### DIFF
--- a/src/Account.ts
+++ b/src/Account.ts
@@ -43,9 +43,8 @@ export default class Account {
         this.refinable.provider
       );
       const balance = await token.balanceOf(this.ethAddress);
-      result = BigNumber.from(balance)
-        .div(10 ** decimals)
-        .toString();
+      const exp = BigNumber.from(10).pow(decimals);
+      result = BigNumber.from(balance).div(exp).toString();
     } catch (e) {
       console.error(`ERROR: Failed to get the balance: ${e.message}`);
     }


### PR DESCRIPTION
```
>  BigNumber.from(1).div(10 ** 18).toString()
Uncaught:
Error: overflow (fault="overflow", operation="BigNumber.from", value=1000000000000000000, code=NUMERIC_FAULT, version=bignumber/5.5.0)
    at Logger.makeError (/Users/mihaibercu/work/refinable/refinable-sdk/node_modules/@ethersproject/logger/lib/index.js:199:21)
    at Logger.throwError (/Users/mihaibercu/work/refinable/refinable-sdk/node_modules/@ethersproject/logger/lib/index.js:208:20)
    at throwFault (/Users/mihaibercu/work/refinable/refinable-sdk/node_modules/@ethersproject/bignumber/lib/bignumber.js:305:19)
    at Function.BigNumber.from (/Users/mihaibercu/work/refinable/refinable-sdk/node_modules/@ethersproject/bignumber/lib/bignumber.js:208:17)
    at BigNumber.div (/Users/mihaibercu/work/refinable/refinable-sdk/node_modules/@ethersproject/bignumber/lib/bignumber.js:65:27) {
  reason: 'overflow',
  code: 'NUMERIC_FAULT',
  fault: 'overflow',
  operation: 'BigNumber.from',
  value: 1000000000000000000
}

> BigNumber.from(1).div(BigNumber.from(10).pow(18)).toString()
'0'
```