### PR TITLE
fix: use new signer for testnet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refinableco/refinable-sdk",
-  "version": "3.0.2-next.2",
+  "version": "3.0.2-next.3",
   "description": "The Refinable SDK allows you to easily interact with the Refinable Marketplace to mint, sell and buy NFTs",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/config/sdk.ts
+++ b/src/config/sdk.ts
@@ -23,8 +23,8 @@ export const ipfsUrl = {
 
 export const signer = {
   [Environment.Mainnet]: "0xD2E49cfd5c03a72a838a2fC6bB5f6b46927e731A",
-  [Environment.Testnet]: "0xd4039eB67CBB36429Ad9DD30187B94f6A5122215",
-  [Environment.Local]: "0xd4039eB67CBB36429Ad9DD30187B94f6A5122215",
+  [Environment.Testnet]: "0x9d2b8DFd7B8F33Cf84499Ac2df74896174AAb98C",
+  [Environment.Local]: "0x9d2b8DFd7B8F33Cf84499Ac2df74896174AAb98C",
 };
 
 export const getContractsTags = (environment: Environment): ContractTag[] => {


### PR DESCRIPTION
Use new signer while deploying contracts through the SDK on testnet and local. This fixes test mints.