### PR TITLE
fix: Main repo resoultion for 3.0.3-next.1 is v3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refinableco/refinable-sdk",
-  "version": "3.0.3-next.1",
+  "version": "3.0.4-next.1",
   "description": "The Refinable SDK allows you to easily interact with the Refinable Marketplace to mint, sell and buy NFTs",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
Released 3.0.3-next.1 by mistake, while 3.0.3 was already published. yarn.lock resolution is:
```
+"@refinableco/refinable-sdk@npm:^3.0.3-next.1":
+  version: 3.0.3
+  resolution: "@refinableco/refinable-sdk@npm:3.0.3"
```
which is not what i want. publish `3.0.4-next.1` to fix that