### PR TITLE
fix: captureEx error some browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refinableco/refinable-sdk",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "The Refinable SDK allows you to easily interact with the Refinable Marketplace to mint, sell and buy NFTs",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/errors/NotEnoughSupplyError.ts
+++ b/src/errors/NotEnoughSupplyError.ts
@@ -3,6 +3,8 @@ export class NotEnoughSupplyError extends Error {
     super("There is not enough supply left for this action");
     this.name = this.constructor.name;
 
-    Error.captureStackTrace(this, this.constructor);
+    // Not supported in some browsers
+    if (typeof Error.captureStackTrace === "function")
+      Error.captureStackTrace(this, this.constructor);
   }
 }

--- a/src/errors/SimulationFailedError.ts
+++ b/src/errors/SimulationFailedError.ts
@@ -5,7 +5,9 @@ export class SimulationFailedError extends Error {
     super("Simulation Failed");
     this.name = this.constructor.name;
 
-    Error.captureStackTrace(this, this.constructor);
+    // Not supported in some browsers
+    if (typeof Error.captureStackTrace === "function")
+      Error.captureStackTrace(this, this.constructor);
   }
 }
 

--- a/src/errors/TransactionError.ts
+++ b/src/errors/TransactionError.ts
@@ -21,7 +21,10 @@ export class TransactionError extends Error {
 
     super(reason);
 
-    Error.captureStackTrace(this, this.constructor);
+    // Not supported in some browsers
+    if (typeof Error.captureStackTrace === "function")
+      Error.captureStackTrace(this, this.constructor);
+
     this.reason = reason;
     this.data = data;
     this.functionInfo = functionInfo;
@@ -31,12 +34,11 @@ export class TransactionError extends Error {
   }
 }
 
-
 /**
- * Recontructs schema and input parameters based on the ABI and the input data 
- * @param data 
- * @param contractInterface 
- * @returns 
+ * Recontructs schema and input parameters based on the ABI and the input data
+ * @param data
+ * @param contractInterface
+ * @returns
  */
 function parseFunctionInfo(
   data: string,


### PR DESCRIPTION
Fixes `Error.captureStackTrace is not a function. (In 'Error.captureStackTrace(o,o.constructor)', 'Error.captureStackTrace' is undefined)` from Sentry. Some browsers, like apparently chrome mobile ios, dont support this method.