### PR TITLE
fix: let the prebsc-1-s1 to be the getBalance node

### DIFF
--- a/src/config/chains.ts
+++ b/src/config/chains.ts
@@ -98,12 +98,12 @@ export const chainMap: Record<Chain, IChainConfig> = {
     networkType: NetworkType.TESTNET,
     chainType: ChainType.BSC,
     nodeUri: [
-      "https://data-seed-prebsc-2-s3.binance.org:8545/",
       "https://data-seed-prebsc-1-s1.binance.org:8545/",
       "https://data-seed-prebsc-2-s1.binance.org:8545/",
       "https://data-seed-prebsc-1-s2.binance.org:8545/",
       "https://data-seed-prebsc-2-s2.binance.org:8545/",
       "https://data-seed-prebsc-1-s3.binance.org:8545/",
+      "https://data-seed-prebsc-2-s3.binance.org:8545/",
     ],
     explorerUri: "https://testnet.bscscan.com/",
     supportedCurrencies: [


### PR DESCRIPTION
BSC Testnet: The nodeUri[0] is `prebsc-2-s3` and it's not allowed with cross-orign request so the getBalance API got a CORS error on requesting. I move it down and let the `prebsc-1-s1` to be the request node.