### PR TITLE
fix: unable to list for sale for lazy contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refinableco/refinable-sdk",
-  "version": "4.2.0-next.7",
+  "version": "4.2.0-next.8",
   "description": "The Refinable SDK allows you to easily interact with the Refinable Marketplace to mint, sell and buy NFTs",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/nft/AbstractEvmNFT.ts
+++ b/src/nft/AbstractEvmNFT.ts
@@ -123,7 +123,11 @@ export abstract class AbstractEvmNFT extends AbstractNFT {
     const isERC1155 = isERC1155Item(this);
     const type = isERC1155
       ? [ContractTypes.Erc1155Token, ContractTypes.Erc1155WhitelistedToken]
-      : [ContractTypes.Erc721Token, ContractTypes.Erc721WhitelistedToken];
+      : [
+          ContractTypes.Erc721Token,
+          ContractTypes.Erc721WhitelistedToken,
+          ContractTypes.Erc721LazyMintToken,
+        ];
 
     const nftTokenContract =
       await this.refinableEvmClient.contracts.getRefinableContract(


### PR DESCRIPTION
A while back we introduced fetching contracts by both chainId, address and type in order to combat the issue of targetting wrong contracts when working with diamond standard. While we do not use the standard, we are still querying like this, and in the list for fetching tokens, the lazy contract is not there yet.