### PR TITLE
fix: auction actions breaking mainnet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refinableco/refinable-sdk",
-  "version": "4.2.11-next.0",
+  "version": "4.2.12-next.0",
   "description": "The Refinable SDK allows you to easily interact with the Refinable Marketplace to mint, sell and buy NFTs",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/nft/AbstractEvmNFT.ts
+++ b/src/nft/AbstractEvmNFT.ts
@@ -553,7 +553,7 @@ export abstract class AbstractEvmNFT extends AbstractNFT {
       [
         auctionIdOrFetch,
         ...optionalParam(
-          contract.hasTag(ContractTag.AuctionV5_0_0),
+          contract.hasTagSemver("AUCTION", ">=5.0.0"),
           bidAmount, // uint256 bidAmount
           marketConfig.data ?? "0x",
           marketConfig.signature ?? "0x"
@@ -601,7 +601,7 @@ export abstract class AbstractEvmNFT extends AbstractNFT {
     return await contractWrapper.sendTransaction("endAuction", [
       auctionIdOrFetch,
       ...optionalParam(
-        contract.hasTag(ContractTag.AuctionV5_0_0),
+        contract.hasTagSemver("AUCTION", ">=5.0.0"),
         marketConfig.data ?? "0x",
         marketConfig.signature ?? "0x"
       ),


### PR DESCRIPTION
Since previously the newly merged auction params were fixed at v5, our newly deployed contracts 5.0.1 no longer work.