### PR TITLE
improvement: allow access read-only props without being on the correct chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refinableco/refinable-sdk",
-  "version": "4.2.15-next.0",
+  "version": "4.2.16-next.0",
   "description": "The Refinable SDK allows you to easily interact with the Refinable Marketplace to mint, sell and buy NFTs",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/nft/AbstractEvmNFT.ts
+++ b/src/nft/AbstractEvmNFT.ts
@@ -219,7 +219,7 @@ export abstract class AbstractEvmNFT extends AbstractNFT {
 
     const fees: LibPart[] = await serviceFeeContract
       .connect(this.refinable.provider)
-      .contractWrapper.contract.getServiceFees(
+      .contractWrapper.read.getServiceFees(
         FeeType.BUY,
         this.refinable.accountAddress,
         contractAddress,
@@ -424,7 +424,7 @@ export abstract class AbstractEvmNFT extends AbstractNFT {
       auctionContractAddress
     );
 
-    return contractWrapper.contract.getAuctionId(
+    return contractWrapper.read.getAuctionId(
       this.item.contractAddress,
       this.item.tokenId,
       this.refinable.accountAddress
@@ -440,7 +440,7 @@ export abstract class AbstractEvmNFT extends AbstractNFT {
       return 0;
     }
     const minBidIncrementBps: BigNumber =
-      await contractWrapper.contract.minBidIncrementBps();
+      await contractWrapper.read.minBidIncrementBps();
 
     return parseBPS(minBidIncrementBps) / 100;
   }

--- a/src/refinable/RoyaltyRegistry.ts
+++ b/src/refinable/RoyaltyRegistry.ts
@@ -1,5 +1,4 @@
 import { ContractTypes } from "../@types/graphql";
-import { getProviderByNetworkId } from "../config/chains";
 import { RoyaltyType } from "../enums/royalty-type.enum";
 import { LibPart } from "../interfaces/LibPart";
 import { Chain } from "../interfaces/Network";
@@ -10,13 +9,10 @@ export { RoyaltyType };
 
 export class RoyaltyRegistry {
   private contract: ContractWrapper;
-  private chainProvider: any;
   constructor(
     private readonly refinable: Refinable,
     private readonly chainId: Chain
-  ) {
-    this.chainProvider = getProviderByNetworkId(this.chainId);
-  }
+  ) {}
 
   private async _lazyGetContract() {
     if (this.contract) {
@@ -29,7 +25,7 @@ export class RoyaltyRegistry {
         [ContractTypes.RoyaltyRegistry]
       );
 
-    contract.connect(this.refinable.provider ?? this.chainProvider);
+    contract.connect(this.refinable.provider);
 
     this.contract = contract.contractWrapper;
     return this.contract;
@@ -38,7 +34,7 @@ export class RoyaltyRegistry {
   async getRoyaltyInfo(contractAddress: string, tokenId = "1") {
     const lazyContract = await this._lazyGetContract();
 
-    const royaltyInfo = await lazyContract.contract.getRoyaltyInfoForToken(
+    const royaltyInfo = await lazyContract.read.getRoyaltyInfoForToken(
       contractAddress,
       tokenId
     );

--- a/src/refinable/account/EvmAccount.ts
+++ b/src/refinable/account/EvmAccount.ts
@@ -142,6 +142,7 @@ export default class EvmAccount implements Account {
           `function approve(address _spender, uint256 _value)`,
           `function allowance(address _owner, address _spender) public view returns (uint remaining)`,
         ],
+        chainId: (await this._provider.getNetwork()).chainId,
       },
       this.providerOrSigner,
       this.evmOptions

--- a/src/refinable/contract/Contract.ts
+++ b/src/refinable/contract/Contract.ts
@@ -65,6 +65,7 @@ export class Contract implements IContract {
       {
         abi: this.contractABI,
         address: this.contractAddress,
+        chainId: this.chainId,
       },
       signerOrProvider,
       this.evmOptions

--- a/src/refinable/contract/Erc721LazyMintContract.ts
+++ b/src/refinable/contract/Erc721LazyMintContract.ts
@@ -70,28 +70,30 @@ export class Erc721LazyMintContract extends Contract {
   }
 
   async maxTokens(): Promise<number> {
-    const maxTokens = await this.contractWrapper.contract.MAX_TOKENS();
+    const maxTokens = await this.contractWrapper.read.MAX_TOKENS();
 
     return maxTokens.toNumber();
   }
 
   async totalSupply(): Promise<number> {
-    const totalSupply = await this.contractWrapper.contract.totalSupply();
+    const totalSupply = await this.contractWrapper.read.totalSupply();
 
     return totalSupply.toNumber();
   }
 
   isRevealed(): Promise<boolean> {
-    return this.contractWrapper.contract._revealed();
+    return this.contractWrapper.read._revealed();
   }
 
   getSaleSettings(): Promise<SaleSettings> {
-    return this.contractWrapper.contract.saleSettings();
+    return this.contractWrapper.read.saleSettings();
   }
 
   async getNonce(seller: string): Promise<number> {
-    return (await this.contractWrapper.contract.getNonce(seller))?.toNumber();
+    return (await this.contractWrapper.read.getNonce(seller))?.toNumber();
   }
+
+  // **** TX ****
 
   updateSaleSettings(saleSettings: Partial<SaleSettings>) {
     const settings: SaleSettings = {


### PR DESCRIPTION
Currently when trying to fetch royalties or saleSettings, the call sometimes fails. This happens because its trying to fetch it from the current chain rather than the chain the contract is on. This introduces a separate contract instantiated with the chain RPC to fetch read-only variables which dont need the signer.